### PR TITLE
receive_response: fix object decoding

### DIFF
--- a/src/dsf/connections.py
+++ b/src/dsf/connections.py
@@ -125,7 +125,7 @@ class BaseConnection:
     def receive_response(self):
         """Receive a base response from the server"""
         json_string = self.receive_json()
-        return json.loads(json_string, object_hook=responses.decode_response)
+        return responses.decode_response(json.loads(json_string))
 
     def receive_json(self) -> str:
         """Receive the JSON response from the server"""


### PR DESCRIPTION
Correct me if I'm wrong but the intent of [this line](https://github.com/Duet3D/dsf-python/blob/bfbf765775bb0e7c3ba840400f676e1b4dbfd827/src/dsf/connections.py#L128) is to encapsulate the top level object into the `Response` class and **not** to recursively encapsulate every nested object.

The way it is in the source code it tries to do it recursively since `object_hook()` is called on every nested object. This was breaking `get_object_model()`.